### PR TITLE
xz compression should be supported for imgapi images

### DIFF
--- a/lib/imgmanifest.js
+++ b/lib/imgmanifest.js
@@ -1106,7 +1106,7 @@ var validators = {
 
     files: function validateFiles(manifest) {
         var errs = [];
-        var VALID_FILE_COMPRESSIONS = ['gzip', 'bzip2', 'none'];
+        var VALID_FILE_COMPRESSIONS = ['gzip', 'bzip2', 'xz', 'none'];
         var files = manifest.files;
         var activated = boolFromString(manifest.activated);
         // Only push an error if activated is true


### PR DESCRIPTION
This PR adds support for xz compression for imgapi images. Without this change, the imgadm won't be able to install images.