### PR TITLE
TRITON-2304 New image server names

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = https://github.com/davepacheco/javascriptlint.git
+	url = https://github.com/TritonDataCenter/javascriptlint.git
 [submodule "deps/jsstyle"]
 	path = deps/jsstyle
-	url = https://github.com/joyent/jsstyle.git
+	url = https://github.com/TritonDataCenter/jsstyle.git

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,13 @@
 
 (nothing yet)
 
+## 3.2.1
+
+- TOOLS-2525 Everything needs to stop clonging with git:// URLs
+
 ## 3.2.0
 
-TRITON-2228: Linux CN minimum viable product
+- TRITON-2228: Linux CN minimum viable product
 
 ## 3.1.0
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # node-imgmanifest
 
 This repository is part of the Joyent Triton project. See the [contribution
-guidelines](https://github.com/joyent/triton/blob/master/CONTRIBUTING.md)
+guidelines](https://github.com/TritonDataCenter/triton/blob/master/CONTRIBUTING.md)
 and general documentation at the main [Triton
-project](https://github.com/joyent/triton) page.
+project](https://github.com/TritonDataCenter/triton) page.
 
 node-imgmanifest is a node.js lib for working with SmartOS image manifests.
 
@@ -11,8 +11,8 @@ The SmartOS/SDC *Image* world involves a number of pieces:
 
 1. The `imgadm` tool in SmartOS for installing and managing images for VM
    creation.
-2. The IMGAPI server in SmartDataCenter instances.
-3. The Joyent Images API, <https://images.joyent.com>.
+2. The IMGAPI server in Triton instances.
+3. The SmartOS Images API, <https://images.smartos.org>.
 4. Possibly 3rd-party IMGAPI instances.
 5. `*-imgadm` tools for managing the above API servers.
 

--- a/lib/imgmanifest.js
+++ b/lib/imgmanifest.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2022 MNX Cloud, Inc.
  */
 
 /*
@@ -302,7 +303,7 @@ function upgradeManifest(oldManifest) {
  * There are multiple separate validation cases:
  * - In a 'dc' mode IMGAPI (e.g. in SDC).
  *      validateDcManifest
- * - In a 'public' mode IMGAPI (e.g. https://images.joyent.com).
+ * - In a 'public' mode IMGAPI (e.g. https://images.smartos.org).
  *      validatePublicManifest
  * - In a 'private' mode IMGAPI.
  *      validatePrivateManifest

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "imgmanifest",
   "description": "Library for working with Triton/SDC/SmartOS image manifests",
   "version": "3.2.1",
-  "author": "Joyent (joyent.com)",
+  "author": "MNX Cloud (mnxsolutions.com)",
   "main": "./lib/imgmanifest.js",
   "dependencies": {
     "assert-plus": "1.0.0"


### PR DESCRIPTION
No version bump and no npm publish because the only thing changing is comments, documentation, and metadata